### PR TITLE
Add php7-redis package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,7 @@ RUN \
 	php7-xml \
 	php7-xmlreader \
 	php7-zip \
+	php7-redis \
 	samba \
 	sudo \
 	tar \


### PR DESCRIPTION
php7-redis package required to use redis caching.

https://docs.nextcloud.com/server/12/admin_manual/configuration_server/caching_configuration.html

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

